### PR TITLE
Fable support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,5 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
+.ionide

--- a/AlgEff/AlgEff.fsproj
+++ b/AlgEff/AlgEff.fsproj
@@ -31,6 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi"  Exclude="bin\**\*; obj\**\*"  PackagePath="fable\" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\Icon.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>


### PR DESCRIPTION
This PR adds Fable support to the Nuget packaging process. 

After a Nuget release, this should allow AlgEff to be used in Fable. 